### PR TITLE
Implement a threadpool to improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the code for [jackiepi.xyz](https://jackiepi.xyz/), my 
 
 These are the primary components:
 * **landing.html**: A landing page with a rotating globe in the left third of the page, links to other parts of the site, and a brief summary of who I am. Developers may find the way I keep the globe in the same part of the canvas regardless of window geometry interesting.
-* **satellites.html**: The primary feature of this project, an interactive webapp showing all satellites in the SATCAT database provided by [celestrak.org](https://celestrak.org/) in real time. Additional controls in the drop down menu on the right side of the window (the downward pointing arrow below the clock) enable the user to adjust the simulation speed, enable/disable the starry sky background layer, and show or hide all groups of satellites in the scene. Some aspects of this experience are still a work-in-progress and will be updated over the coming weeks.
+* **satellites.html**: The primary feature of this project, an interactive webapp showing all satellites in the SATCAT database provided by [space-track.org](https://space-track.org/) in real time. Additional controls in the drop down menu on the right side of the window (the downward pointing arrow below the clock) enable the user to adjust the simulation speed, enable/disable the starry sky background layer, and show or hide all groups of satellites in the scene. While every effort has been taken to ensure that satellite position calculations are up-to-date, my automated process can occasionally fail causing the computed position to diverge from actual positions. Always use true spacecraft telemetry when performing operations.
 * **nightsky.html**: This is an extra webpage intended to showcase the unique way I am rendering the stars in this application. The page is set up in the style of a threejs example and allows the user to adjust physical parameters of the star mapping shader to get a sense of how the stars are being displayed in the scene.
 * **Pre-processing scripts**: Additional Python pre-processing scripts used to convert data from public databases into the format used by this project. GetStars.py and ImageGen.py are currently in a WIP state and not intended to be used by others.
 
@@ -16,14 +16,56 @@ npm install
 
 ## Building & Running
 ### Prerequisite
-This repository does not contain several .json files that are required for full functionality of the satellite viewing demo (satellites.html), but they can be generated automatically using the provided pre-processing script, tle_parser.py. Run the following commands in the top-level directory of this repository:
+This repository does not contain several .json files that are required for full functionality of the satellite viewing demo (satellites.html), but they can be generated automatically using the provided pre-processing script, tle_parser.py. Since the celestrak database no longer allows full catalog API queries, the process to obtain the latest TLEs for all on-orbit objects is more involved for the space-track API. First, you will need to register for an account on [space-track.org](https://space-track.org/) and store your credentials in an encrypted file on your device.
+
 ```bash
-wget -O active_satellites.txt "https://celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=tle"
-wget -O full_catalog.txt "https://celestrak.org/NORAD/elements/catalog.txt"
-scripts/tle_parser.py active_satellites.txt full_catalog.txt  -w static/groups --dev
+# OPTIONAL: Create a GPG key if you do not already have one, I prefer to not use a passphrase for this
+# If you know what you're doing, you can use an existing key pair of course
+gpg --batch --generate-key <<EOF
+Key-Type: default
+Key-Length: 3072
+Subkey-Type: default
+Subkey-Length: 3072
+Name-Real: Space-Track API
+Name-Email: spacetrack@localhost
+Expire-Date: 0
+%no-protection
+%commit
+EOF
+
+echo "your_username
+your_password" > spacetrack-creds.txt
+gpg --encrypt --recipient spacetrack@localhost spacetrack-creds.txt
+shred -u spacetrack-creds.txt
+mv spacetrack-creds.gpg ~/.spacetrack-creds.gpg
 ```
 
+### Performing Three Line Element (TLE) Queries Locally
 This step is handled nightly by a script (not included in this repository) that gets initiated by a systemd timer on my VPS.
+
+```bash
+CREDS=$(sudo gpg --quiet --decrypt ~/.spacetrack-creds.gpg)
+# USER and PASS variables are retained in scope so best practice is to
+# set the variables to a blank string after running these queries
+USER=$(echo "$CREDS" | head -n1)
+PASS=$(echo "$CREDS" | tail -n1)
+
+wget --post-data="identity=$USER&password=$PASS" \
+    --save-cookies cookies.txt \
+    --keep-session-cookies \
+    https://www.space-track.org/ajaxauth/login
+
+if [ $? -eq 0 ]; then
+    wget --load-cookies cookies.txt \
+        "https://www.space-track.org/basicspacedata/query/class/gp/decay_date/null-val/epoch/%3Enow-30/orderby/norad_cat_id/format/3le" \
+        -O full_catalog.txt
+    rm cookies.txt
+fi
+
+wget -O active_satellites.txt "https://celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=tle"
+
+scripts/tle_parser.py active_satellites.txt full_catalog.txt -w static/groups
+```
 
 ### Dev Setup
 This is a vite project, so to run the project locally, simply run the script `npm run dev` and your browser should automatically open a tab on [localhost:5173](http://localhost:5173/):

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mv spacetrack-creds.gpg ~/.spacetrack-creds.gpg
 This step is handled nightly by a script (not included in this repository) that gets initiated by a systemd timer on my VPS.
 
 ```bash
-CREDS=$(sudo gpg --quiet --decrypt ~/.spacetrack-creds.gpg)
+CREDS=$(gpg --quiet --decrypt ~/.spacetrack-creds.gpg)
 # USER and PASS variables are retained in scope so best practice is to
 # set the variables to a blank string after running these queries
 USER=$(echo "$CREDS" | head -n1)

--- a/src/workerPool.js
+++ b/src/workerPool.js
@@ -1,0 +1,98 @@
+// workerPool.js
+import Worker from './satelliteWorker.js?worker';
+
+export class WorkerPool {
+    constructor(numWorkers = navigator.hardwareConcurrency || 4) {
+        this.workers = [];
+        this.workQueue = new Map(); // Maps group URLs to worker indices
+        this.currentWorkerIndex = 0;
+
+        // Initialize workers
+        for (let i = 0; i < numWorkers; i++) {
+            const worker = new Worker();
+            worker.onmessage = this.handleWorkerMessage.bind(this, i);
+            this.workers.push({
+                worker: worker,
+                groups: new Set(), // Keep track of which groups this worker handles
+                busy: false
+            });
+        }
+
+        this.messageCallbacks = new Map(); // For storing callbacks by group
+    }
+
+    // Register a callback for a specific group
+    registerCallback(groupUrl, callback) {
+        this.messageCallbacks.set(groupUrl, callback);
+    }
+
+    // Handle messages from any worker in the pool
+    handleWorkerMessage(workerIndex, event) {
+        const { type, payload } = event.data;
+
+        // Find the callback for this group
+        if (type === 'eventLoopStarted') {
+            const callback = this.messageCallbacks.get(payload);
+            if (callback) {
+                callback(event.data);
+            }
+        } else if (type === 'posVel') {
+            const callback = this.messageCallbacks.get(payload.group);
+            if (callback) {
+                callback(event.data);
+            }
+        }
+    }
+
+    // Assign a group to the least busy worker
+    getLeastBusyWorker() {
+        let minGroups = Infinity;
+        let selectedWorker = 0;
+
+        this.workers.forEach((workerInfo, index) => {
+            if (workerInfo.groups.size < minGroups) {
+                minGroups = workerInfo.groups.size;
+                selectedWorker = index;
+            }
+        });
+
+        return selectedWorker;
+    }
+
+    // Send a message to the appropriate worker for a group
+    postMessage(groupUrl, message) {
+        let workerIndex;
+
+        // If this group is already assigned to a worker, use that worker
+        if (this.workQueue.has(groupUrl)) {
+            workerIndex = this.workQueue.get(groupUrl);
+        } else {
+            // Assign to the least busy worker
+            workerIndex = this.getLeastBusyWorker();
+            this.workQueue.set(groupUrl, workerIndex);
+            this.workers[workerIndex].groups.add(groupUrl);
+        }
+
+        this.workers[workerIndex].worker.postMessage(message);
+    }
+
+    // Remove a group from a worker's assignments
+    removeGroup(groupUrl) {
+        if (this.workQueue.has(groupUrl)) {
+            const workerIndex = this.workQueue.get(groupUrl);
+            this.workers[workerIndex].groups.delete(groupUrl);
+            this.workQueue.delete(groupUrl);
+            this.messageCallbacks.delete(groupUrl);
+        }
+    }
+
+    // Terminate all workers in the pool
+    terminate() {
+        this.workers.forEach(workerInfo => {
+            workerInfo.worker.terminate();
+        });
+        this.workers = [];
+        this.workQueue.clear();
+        this.messageCallbacks.clear();
+    }
+}

--- a/static/groups/index.json
+++ b/static/groups/index.json
@@ -38,7 +38,7 @@
     "gpName": "planet",
     "country": "planet",
     "baseColor": "#029da4",
-    "count": 113,
+    "count": 112,
     "entities": "/groups/planet.json"
   },
   "Space Stations": {
@@ -70,7 +70,7 @@
     "gpName": "starlink",
     "country": "us",
     "baseColor": "#6b6b6b",
-    "count": 6844,
+    "count": 6834,
     "entities": "/groups/starlink.json"
   },
   "Telesat": {
@@ -82,12 +82,12 @@
   },
   "Active": {
     "gpName": "active",
-    "count": 2866,
+    "count": 2877,
     "baseColor": "#1b1bf9",
     "entities": "/groups/active.json"
   },
   "Debris": {
-    "count": 50315,
+    "count": 16220,
     "entities": "/groups/debris.json"
   }
 }


### PR DESCRIPTION
When a large number of satellites are displayed at the same time, a single web worker was saturating, leading to lower performance of the satellite animation. This change addresses that by replacing the single dedicated webworker with a pool of workers and splitting work between them by satellite group. This should hopefully also improve battery usage on mobile devices by avoiding saturating a single core on the user's device.